### PR TITLE
Fix FakeIP loop for proxy check domain

### DIFF
--- a/forkop/files/usr/lib/singbox/generator.uc
+++ b/forkop/files/usr/lib/singbox/generator.uc
@@ -2909,6 +2909,12 @@ function add_service_route_rules(config, sections) {
     }
     if (first != null) {
         push(config.route.rules, {
+            action: "resolve",
+            inbound: tproxy_inbound_matcher(),
+            server: runtime_constants.DNS_SERVER_TAG,
+            domain: runtime_constants.CHECK_PROXY_IP_DOMAIN
+        });
+        push(config.route.rules, {
             action: "route",
             inbound: tproxy_inbound_matcher(),
             outbound: outbound_tag(first[".name"]),


### PR DESCRIPTION
## Summary

Resolve `CHECK_PROXY_IP_DOMAIN` before routing it through the first active proxy/ByeDPI/Zapret section.

## Root cause

`ip.podkop.fyi` can be resolved to a FakeIP before it reaches the local ByeDPI SOCKS outbound. The resulting connection is intercepted by TPROXY again and loops back into the same outbound, eventually filling `nf_conntrack`.

## Change

Add a `resolve` rule for `CHECK_PROXY_IP_DOMAIN` immediately before the existing service `route` rule.

## Validation

Tested on OpenWrt 25.12.5 with Forkop 1.0.5 / sing-box-extended 1.13.14-extended-2.5.3.

Before: `nf_conntrack_count` reached `31232/31232`.
After: dropped to a few hundred connections and stayed stable under YouTube load.

Fixes #74