### PR TITLE
Avoid hijacking non-DNS traffic on port 53

### DIFF
--- a/forkop/files/usr/lib/singbox/route.uc
+++ b/forkop/files/usr/lib/singbox/route.uc
@@ -27,7 +27,6 @@ function config(settings, runtime) {
     let result = {
         rules: [
             { action: "sniff", inbound: sniff_inbounds },
-            { action: "hijack-dns", port: 53 },
             { action: "hijack-dns", protocol: "dns" }
         ],
         rule_set: [],


### PR DESCRIPTION
## Summary

Remove the unconditional `hijack-dns` rule that matches only destination port 53 and keep protocol-based DNS hijacking after sniffing.

## Root cause

Some clients send non-DNS UDP traffic to destination port 53. The unconditional rule:

```ucode
{ action: "hijack-dns", port: 53 },
```

forwards those packets to the sing-box DNS parser, producing errors such as `bad rdata`, `buffer size too small`, and `bad question size`.

A packet capture reproduced this with:

`192.168.10.147:49103 -> 172.238.246.64:53`, UDP length 1312, non-DNS binary payload.

## Change

Keep:

```ucode
{ action: "sniff", inbound: sniff_inbounds },
{ action: "hijack-dns", protocol: "dns" }
```

and remove the port-only hijack rule.

## Validation

After the change:
- `sing-box check -c /etc/sing-box/config.json` succeeds;
- regular DNS resolution works;
- YouTube FakeIP resolution works;
- the non-DNS UDP/53 traffic is no longer forced into the DNS parser.

Fixes #79