### PR TITLE
Handle independent_cache compatibility with sing-box 1.14

### DIFF
--- a/forkop/files/usr/lib/singbox/generator.uc
+++ b/forkop/files/usr/lib/singbox/generator.uc
@@ -21,6 +21,7 @@ let fixture_uci_data = null;
 let runtime_settings_cache = null;
 let runtime_ruleset_folder = runtime_constants.TMP_RULESET_FOLDER;
 let runtime_supports_xhttp = true;
+let runtime_sing_box_version = "";
 
 let as_string = common.as_string;
 let read_json_file = common.read_json_file;
@@ -47,6 +48,16 @@ let url_path = runtime_url.path;
 let url_query_params = runtime_url.query_params;
 
 const CONFIG_NAME = "forkop";
+
+function sing_box_uses_legacy_independent_cache(value) {
+    let matched = match(as_string(value), /^([0-9]+)[.]([0-9]+)/);
+    if (matched == null)
+        return true;
+
+    let major = int(matched[1], 10);
+    let minor = int(matched[2], 10);
+    return major < 1 || (major == 1 && minor < 14);
+}
 
 function parent_dir(path) {
     path = as_string(path);
@@ -461,7 +472,7 @@ function base_config(settings, service_address, runtime_context) {
     runtime_context.dns_health_inbounds = dns_config.sniff_inbounds;
     runtime_context.default_domain_resolver = runtime_dns.default_domain_resolver(settings);
 
-    return {
+    let result = {
         log: {
             disabled: false,
             level: log_level,
@@ -471,8 +482,7 @@ function base_config(settings, service_address, runtime_context) {
             servers: dns_servers,
             rules: dns_rules,
             final: runtime_constants.DNS_SERVER_TAG,
-            strategy: option(settings, "dns_strategy", "prefer_ipv4"),
-            independent_cache: true
+            strategy: option(settings, "dns_strategy", "prefer_ipv4")
         },
         ntp: {},
         certificate: {},
@@ -493,6 +503,9 @@ function base_config(settings, service_address, runtime_context) {
             clash_api: clash_api_config(settings, service_address)
         }
     };
+    if (sing_box_uses_legacy_independent_cache(runtime_sing_box_version))
+        result.dns.independent_cache = true;
+    return result;
 }
 
 function supported_subscription_outbound(outbound) {
@@ -3005,10 +3018,11 @@ function add_server_routes(config, servers, sections) {
     }
 }
 
-function generate_config(output_path, service_address, mwan3_active, supports_xhttp, deferred_sections) {
+function generate_config(output_path, service_address, mwan3_active, supports_xhttp, deferred_sections, sing_box_version) {
     runtime_supports_xhttp = supports_xhttp == null || as_string(supports_xhttp) == ""
         ? true
         : cli_bool(supports_xhttp);
+    runtime_sing_box_version = as_string(sing_box_version || "");
     let cursor = uci_cursor();
     cursor.load(CONFIG_NAME);
     runtime_settings_cache = object_or_empty(cursor.get_all(CONFIG_NAME, "settings"));
@@ -3048,11 +3062,11 @@ function generate_config(output_path, service_address, mwan3_active, supports_xh
     }
 }
 
-function generate_config_fixture(fixture_path, output_path, service_address, mwan3_active, supports_xhttp, deferred_sections) {
+function generate_config_fixture(fixture_path, output_path, service_address, mwan3_active, supports_xhttp, deferred_sections, sing_box_version) {
     use_fixture_cursor(fixture_path);
     runtime_subscription.set_section_cache_dir(output_path + ".section-cache");
     runtime_ruleset_folder = output_path + ".rulesets";
-    generate_config(output_path, service_address, mwan3_active, supports_xhttp, deferred_sections);
+    generate_config(output_path, service_address, mwan3_active, supports_xhttp, deferred_sections, sing_box_version);
 }
 
 function stdin_length() {
@@ -3166,9 +3180,9 @@ function object_nonempty_stdin() {
 let mode = ARGV[0] || "";
 
 if (mode == "generate-config")
-    generate_config(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5] || "");
+    generate_config(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5] || "", ARGV[6] || "");
 else if (mode == "generate-config-fixture")
-    generate_config_fixture(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6] || "");
+    generate_config_fixture(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6] || "", ARGV[7] || "");
 else if (mode == "stdin-length")
     stdin_length();
 else if (mode == "stdin-contains")

--- a/forkop/files/usr/lib/singbox/runtime.uc
+++ b/forkop/files/usr/lib/singbox/runtime.uc
@@ -803,7 +803,8 @@ function init_config(populate_nft, caches_prepared, no_refresh, prepared_deferre
             service_listen_address_value(settings),
             mwan3_active ? "1" : "0",
             sing_box_is_extended(sing_box_version()) ? "1" : "0",
-            deferred_sections
+            deferred_sections,
+            sing_box_version()
         ]) + " >" + shell_quote(runtime_log) + " 2>&1"
     );
     if (generate_status != 0) {

--- a/tests/sing_box_114_independent_cache.sh
+++ b/tests/sing_box_114_independent_cache.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORKOP_LIB="$ROOT_DIR/forkop/files/usr/lib"
+GENERATOR="$FORKOP_LIB/singbox/generator.uc"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+cat >"$WORK_DIR/fixture.json" <<'JSON'
+{
+  "settings": {
+    ".name": "settings",
+    ".type": "settings",
+    "config_path": "/tmp/sing-box/config.json",
+    "dns_server": "1.1.1.1",
+    "bootstrap_dns_server": "1.1.1.1",
+    "service_listen_address": "127.0.0.1"
+  },
+  "section": [
+    {
+      ".name": "proxy",
+      ".type": "section",
+      "enabled": "1",
+      "action": "outbound",
+      "outbound_json": "{\"type\":\"direct\"}",
+      "domain_suffix": [ "example.org" ]
+    }
+  ]
+}
+JSON
+
+generate_for_version() {
+  local version="$1"
+  local output="$2"
+  mkdir -p "$output.section-cache" "$output.rulesets"
+  ucode -L "$FORKOP_LIB" "$GENERATOR" generate-config-fixture \
+    "$WORK_DIR/fixture.json" "$output" "127.0.0.1" "0" "1" "" "$version"
+}
+
+generate_for_version "1.13.18-extended-2.6.5" "$WORK_DIR/sb113.json"
+grep -Fq '"independent_cache":true' "$WORK_DIR/sb113.json" ||
+  fail "sing-box 1.13 must keep independent_cache for legacy semantics"
+
+generate_for_version "1.14.0-extended-2.7.0" "$WORK_DIR/sb114.json"
+if grep -Fq '"independent_cache"' "$WORK_DIR/sb114.json"; then
+  fail "sing-box 1.14 must not receive deprecated independent_cache"
+fi
+
+generate_for_version "" "$WORK_DIR/unknown.json"
+grep -Fq '"independent_cache":true' "$WORK_DIR/unknown.json" ||
+  fail "unknown sing-box version must preserve legacy behavior"
+
+printf 'sing-box 1.14 independent_cache compatibility checks passed\n'

--- a/tests/sing_box_114_independent_cache.sh
+++ b/tests/sing_box_114_independent_cache.sh
@@ -48,7 +48,7 @@ generate_for_version() {
 }
 
 generate_for_version "1.13.18-extended-2.6.5" "$WORK_DIR/sb113.json"
-grep -Fq '"independent_cache":true' "$WORK_DIR/sb113.json" ||
+grep -Eq '"independent_cache"[[:space:]]*:[[:space:]]*true' "$WORK_DIR/sb113.json" ||
   fail "sing-box 1.13 must keep independent_cache for legacy semantics"
 
 generate_for_version "1.14.0-extended-2.7.0" "$WORK_DIR/sb114.json"
@@ -57,7 +57,7 @@ if grep -Fq '"independent_cache"' "$WORK_DIR/sb114.json"; then
 fi
 
 generate_for_version "" "$WORK_DIR/unknown.json"
-grep -Fq '"independent_cache":true' "$WORK_DIR/unknown.json" ||
+grep -Eq '"independent_cache"[[:space:]]*:[[:space:]]*true' "$WORK_DIR/unknown.json" ||
   fail "unknown sing-box version must preserve legacy behavior"
 
 printf 'sing-box 1.14 independent_cache compatibility checks passed\n'


### PR DESCRIPTION
## Summary

Make generated DNS configuration compatible with sing-box 1.14 while preserving the existing behavior for older sing-box releases.

## Root cause

Forkop currently always emits:

```json
"independent_cache": true
```

Starting with sing-box 1.14 this option is deprecated and the generated configuration is rejected by Forkop's strict `sing-box check` path because the warning is treated as a fatal validation result.

## Change

- pass the detected sing-box version into the config generator;
- keep `dns.independent_cache = true` for sing-box versions before 1.14;
- omit the option for sing-box 1.14 and newer;
- preserve the legacy behavior when the version cannot be determined;
- add a regression test covering 1.13, 1.14, and unknown-version behavior.

This avoids changing DNS cache semantics for currently supported pre-1.14 installations while allowing 1.14+ to start normally.

## Validation

The regression fixture verifies that:

- `1.13.18-extended-2.6.5` still contains `independent_cache: true`;
- `1.14.0-extended-2.7.0` does not contain `independent_cache`;
- an unknown version keeps the legacy option.

Fixes #98