### PR TITLE
Fix mwan3 validation on OpenWrt 25.12

### DIFF
--- a/forkop/files/usr/lib/config/validator.uc
+++ b/forkop/files/usr/lib/config/validator.uc
@@ -662,7 +662,8 @@ function mwan3_has_enabled_interface() {
 }
 
 function mwan3_has_enabled_interface_from_sections() {
-    for (let section in uci_core().section_objects("mwan3", "interface"))
+    let core = uci_core();
+    for (let section in core.section_objects("mwan3", "interface"))
         if (option(section, "enabled", "0") == "1")
             return true;
     return false;
@@ -2142,6 +2143,8 @@ else if (mode == "dhcp-has-https-dns-proxy-options")
     dhcp_has_https_dns_proxy_options_exit(ARGV[1]);
 else if (mode == "mwan3-has-enabled-interface")
     exit(mwan3_has_enabled_interface() ? 0 : 1);
+else if (mode == "mwan3-has-enabled-interface-from-sections")
+    exit(mwan3_has_enabled_interface_from_sections() ? 0 : 1);
 else if (mode == "mwan3-is-active")
     exit(mwan3_is_active() ? 0 : 1);
 else if (mode == "check-requirements")

--- a/forkop/files/usr/lib/config/validator.uc
+++ b/forkop/files/usr/lib/config/validator.uc
@@ -662,7 +662,9 @@ function mwan3_has_enabled_interface() {
 }
 
 function mwan3_has_enabled_interface_from_sections() {
-    let core = uci_core();
+    if (uci_core_module == null)
+        uci_core_module = require("core.uci");
+    let core = uci_core_module;
     for (let section in core.section_objects("mwan3", "interface"))
         if (option(section, "enabled", "0") == "1")
             return true;

--- a/tests/mwan3_validator_sections.sh
+++ b/tests/mwan3_validator_sections.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FORKOP_LIB="$ROOT_DIR/forkop/files/usr/lib"
+VALIDATOR="$FORKOP_LIB/config/validator.uc"
+WORK_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  exit 1
+}
+
+cat >"$WORK_DIR/enabled.state" <<'EOF'
+mwan3.wan=interface
+mwan3.wan.enabled=1
+mwan3.backup=interface
+mwan3.backup.enabled=0
+EOF
+
+FORKOP_UCI_STATE_FILE="$WORK_DIR/enabled.state" \
+  ucode -L "$FORKOP_LIB" "$VALIDATOR" mwan3-has-enabled-interface-from-sections ||
+  fail "enabled mwan3 interface must be detected through core.uci"
+
+cat >"$WORK_DIR/disabled.state" <<'EOF'
+mwan3.wan=interface
+mwan3.wan.enabled=0
+EOF
+
+if FORKOP_UCI_STATE_FILE="$WORK_DIR/disabled.state" \
+  ucode -L "$FORKOP_LIB" "$VALIDATOR" mwan3-has-enabled-interface-from-sections; then
+  fail "disabled mwan3 interfaces must not be reported as active"
+fi
+
+printf 'mwan3 validator section checks passed\n'


### PR DESCRIPTION
## Summary

Avoid the `Type error: left-hand side is not a function` failure in mwan3 detection on affected OpenWrt/ucode builds.

## Root cause

The validator originally called the lazily loaded UCI module and invoked `section_objects()` on the temporary expression in one statement:

```ucode
uci_core().section_objects("mwan3", "interface")
```

On the affected ucode runtime this fails before mwan3 can be evaluated.

Integration CI also exposed a second ucode compatibility detail: simply changing this to `let core = uci_core()` was still vulnerable in the fixture path because the helper call itself occurs before the later `uci_core()` function declaration is available in that execution path.

The final implementation therefore initializes the cached `core.uci` module directly inside the mwan3 section helper and then calls `section_objects()` through that stable module reference.

## Change

Use the existing cached module variable and initialize it locally when needed:

```ucode
if (uci_core_module == null)
    uci_core_module = require("core.uci");
let core = uci_core_module;

for (let section in core.section_objects("mwan3", "interface"))
```

This avoids both:

- the chained module-expression failure;
- the helper call-order problem found by integration CI.

Also expose a small fixture entry point and add a regression test covering both enabled and disabled mwan3 interfaces through Forkop's fake-UCI backend.

## Validation

The regression test verifies that:

- an enabled `mwan3` interface is detected;
- a configuration containing only disabled interfaces is not reported as active.

The corrected PR was also included in a combined integration branch with the other pending fixes; Backend CI, Frontend CI, and Differential ShellCheck all pass.

Fixes #62
Fixes #87