### PR TITLE
Use monotonic clock for Priority scheduling

### DIFF
--- a/forkop/files/usr/lib/singbox/priority.uc
+++ b/forkop/files/usr/lib/singbox/priority.uc
@@ -78,7 +78,8 @@ function log_message(message, level) {
 }
 
 function now_seconds() {
-    return int(clock()[0]);
+    // Priority intervals must not depend on wall-clock/NTP adjustments.
+    return int(clock(true)[0]);
 }
 
 function duration_to_milliseconds(value, fallback_ms) {
@@ -486,7 +487,9 @@ else if (mode == "select-fixture")
     select_fixture(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5]);
 else if (mode == "select-faster-fixture")
     select_faster_fixture(ARGV[1], ARGV[2], ARGV[3], ARGV[4]);
+else if (mode == "now-seconds-fixture")
+    print(now_seconds(), "\n");
 else {
-    warn("Usage: singbox/priority.uc <start-runtime|stop-runtime|worker|select-fixture|select-faster-fixture>\n");
+    warn("Usage: singbox/priority.uc <start-runtime|stop-runtime|worker|select-fixture|select-faster-fixture|now-seconds-fixture>\n");
     exit(1);
 }

--- a/tests/priority_failover.sh
+++ b/tests/priority_failover.sh
@@ -664,4 +664,14 @@ same_level="$(ucode -L "$FORKOP_LIB" "$PRIORITY_UC" select-faster-fixture \
 printf '%s\n' "$same_level" | grep -Fq '"tag": "b"' ||
   fail "same-level switching should compare candidates with the active delay from the same pass"
 
+priority_now="$(ucode -L "$FORKOP_LIB" "$PRIORITY_UC" now-seconds-fixture)"
+monotonic_now="$(ucode -e 'print(clock(true)[0], "\n")')"
+case "$priority_now:$monotonic_now" in
+  *[!0-9:]*|'':*) fail "Priority monotonic clock fixture returned invalid data" ;;
+esac
+clock_delta=$((priority_now - monotonic_now))
+[ "$clock_delta" -lt 0 ] && clock_delta=$((-clock_delta))
+[ "$clock_delta" -le 2 ] ||
+  fail "Priority scheduling must use ucode CLOCK_MONOTONIC"
+
 printf 'Priority failover checks passed\n'


### PR DESCRIPTION
## Summary
Use a monotonic clock for Priority worker scheduling instead of wall-clock time.

## Root cause
Priority schedules `nextActiveCheck`, `nextRecoveryCheck`, and `nextFastestCheck` from `now_seconds()`, which currently uses ucode `clock()` (`CLOCK_REALTIME`). Wall-clock adjustments (for example NTP corrections on OpenWrt) can move time backwards and leave scheduled checks far in the future, while the worker itself remains alive.

The issue diagnostics confirmed that:
- the Priority worker is running;
- `switch_to_faster_same_priority=true` and `fastest_check_interval=5m` reach the runtime cache;
- latency probes return valid delays and find faster candidates;
- manual `set_group_proxy` succeeds and immediately changes the selector.

That isolates the failure to worker scheduling/state before the switch API call.

## Change
- use `clock(true)` / `CLOCK_MONOTONIC` in `now_seconds()`;
- add a regression fixture asserting that Priority scheduling follows the monotonic clock.

This keeps interval scheduling independent of wall-clock/NTP changes.

Fixes #96